### PR TITLE
Group actions/* dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      actions:
+        patterns:
+        - "actions/*"


### PR DESCRIPTION
Not only for reducing the amount of PRs, but also due make sure we capture multiple related updates that must come together (especially around artifacts and GH pages deployments)